### PR TITLE
Export expected id for mangle rune

### DIFF
--- a/Shared.lua
+++ b/Shared.lua
@@ -92,6 +92,14 @@ function Env.StatBiggerThanStat(stat1, stat2)
     return select(2, UnitStat("player", statId1)) > select(2, UnitStat("player", statId2))
 end
 
+-- Some runes learn multiple spells, i.e. the learnedAbilitySpellIDs array of the
+-- rune data returned by C_Engraving.GetRuneForEquipmentSlot and C_Engraving.GetRuneForInventorySlot
+-- has multiple entries. The sim uses one of those Ids to indentify runes.
+-- Map the first spell Id to the expected spell Id for runes that do not have it at position 1.
+local runeSpellRemap = {
+    [407993] = 407995, -- Mangle: The bear version is expected.
+}
+
 ---Get rune spell from an item in a slot, if item has a rune engraved.
 ---@param slotId integer
 ---@param bagId integer|nil If not nil check bag items instead of equipped items.
@@ -112,7 +120,11 @@ function Env.GetEngravedRuneSpell(slotId, bagId)
     end
 
     if runeData then
-        return runeData.learnedAbilitySpellIDs[1]
+        local firstSpellId = runeData.learnedAbilitySpellIDs[1]
+        if runeSpellRemap[firstSpellId] then
+            return runeSpellRemap[firstSpellId]
+        end
+        return firstSpellId
     end
 end
 

--- a/WowSimsExporter-Vanilla.toc
+++ b/WowSimsExporter-Vanilla.toc
@@ -1,5 +1,5 @@
-## Title: WowSimsExporter v2.7 |cffff8000Classic SoD|r
-## Version: 2.7
+## Title: WowSimsExporter v2.8 |cffff8000Classic SoD|r
+## Version: 2.8
 ## Author: generalwrex(Natop of Old Blanchy), namreeb, coolmodi(FelixPflaum), riotdog
 ## Interface: 11500
 ## Notes: This is an exporter written to quickly export your character to https://wowsims.github.io/sod/ for simulations.

--- a/WowSimsExporter-Wrath.toc
+++ b/WowSimsExporter-Wrath.toc
@@ -1,5 +1,5 @@
-## Title: WowSimsExporter v2.7 |c0000ffffWOTLK|r
-## Version: 2.7
+## Title: WowSimsExporter v2.8 |c0000ffffWOTLK|r
+## Version: 2.8
 ## Author: generalwrex(Natop of Old Blanchy), namreeb, coolmodi(FelixPflaum), riotdog
 ## Interface: 30403
 ## Notes: This is an exporter written to quickly export your character to https://wowsims.github.io/wotlk/ for simulations.


### PR DESCRIPTION
Sim expects the bear spell for the rune, cat spell was exported. I think mangle is the only rune to even have multiple spells in learnedAbilitySpellIDs, so everything else should be fine.