### PR TITLE
[FIX] Nullable gems in previous index

### DIFF
--- a/ExportStructures/ItemSpec.lua
+++ b/ExportStructures/ItemSpec.lua
@@ -54,16 +54,14 @@ function ItemSpecMeta:FillFromItemLink(itemLink)
     self.id = tonumber(itemId)
     self.enchant = tonumber(enchantId)
     if self._structure.gems then
-        if not isGem(gemId1) and isGem(gemId2) or isGem(gemId3) or isGem(gemId4) then
-            gemId1 = 0
-        end
-        if not isGem(gemId2) and isGem(gemId3) or isGem(gemId4) then
-            gemId2 = 0
-        end
-        if not isGem(gemId3) and isGem(gemId4) then
-            gemId3 = 0
-        end
         self.gems = { tonumber(gemId1), tonumber(gemId2), tonumber(gemId3), tonumber(gemId4) }
+        
+        -- Loop over all filled gems and make sure to backwards fill emppy slots with 0.
+        for i = 1, #self.gems do
+            if i > 1 and self.gems[i] and not self.gems[i - 1] then
+                self.gems[i - 1] = 0
+            end 
+        end
     end
     if self._structure.random_suffix then
         self.random_suffix = tonumber(suffixId)

--- a/ExportStructures/ItemSpec.lua
+++ b/ExportStructures/ItemSpec.lua
@@ -56,7 +56,7 @@ function ItemSpecMeta:FillFromItemLink(itemLink)
     if self._structure.gems then
         self.gems = { tonumber(gemId1), tonumber(gemId2), tonumber(gemId3), tonumber(gemId4) }
         
-        -- Loop over all filled gems and make sure to backwards fill emppy slots with 0.
+        -- Loop over all filled gems and make sure to backwards fill empty (nil) gem slots with 0.
         for i = 1, #self.gems do
             if i > 1 and self.gems[i] and not self.gems[i - 1] then
                 self.gems[i - 1] = 0

--- a/ExportStructures/ItemSpec.lua
+++ b/ExportStructures/ItemSpec.lua
@@ -68,13 +68,6 @@ function ItemSpecMeta:FillFromItemLink(itemLink)
     end
 end
 
----Returns if gemID string is a gem.
----@param gemId string
-function isGem(gemId)
-    if gemId == '' then return false end
-    return true
-end
-
 ---Set rune spell from an item in a slot, if item has a rune engraved.
 ---@param slotId integer
 ---@param bagId integer|nil If not nil check bag items instead of equipped items.

--- a/ExportStructures/ItemSpec.lua
+++ b/ExportStructures/ItemSpec.lua
@@ -54,11 +54,27 @@ function ItemSpecMeta:FillFromItemLink(itemLink)
     self.id = tonumber(itemId)
     self.enchant = tonumber(enchantId)
     if self._structure.gems then
+        if not isGem(gemId1) and isGem(gemId2) or isGem(gemId3) or isGem(gemId4) then
+            gemId1 = 0
+        end
+        if not isGem(gemId2) and isGem(gemId3) or isGem(gemId4) then
+            gemId2 = 0
+        end
+        if not isGem(gemId3) and isGem(gemId4) then
+            gemId3 = 0
+        end
         self.gems = { tonumber(gemId1), tonumber(gemId2), tonumber(gemId3), tonumber(gemId4) }
     end
     if self._structure.random_suffix then
         self.random_suffix = tonumber(suffixId)
     end
+end
+
+---Returns if gemID string is a gem.
+---@param gemId string
+function isGem(gemId)
+    if gemId == '' then return false end
+    return true
 end
 
 ---Set rune spell from an item in a slot, if item has a rune engraved.


### PR DESCRIPTION
Fixes this report: https://github.com/wowsims/cata/issues/690

After filling each gem slot it will loop over the array entries and see if the current gem is filled, but the previous empty and fill that gem with `0` to prevent `null` errors when converting the gems to ItemSpec.

**Before**
```
"gems": [null, 52713]
```

**Now**
```
"gems": [0, 52713]
```