### PR TITLE
Reforge improvements

### DIFF
--- a/CataReforgeDetection.lua
+++ b/CataReforgeDetection.lua
@@ -114,6 +114,7 @@ CreateFrame("GameTooltip", "WSEScanningTooltip", nil, "GameTooltipTemplate")
 WSEScanningTooltip:SetOwner(WorldFrame, "ANCHOR_NONE")
 
 local baseItemLink = "item:9333:"
+C_Item.RequestLoadItemDataByID(baseItemLink)
 
 ---@return table<integer, string>
 local function GetBaseItemText()

--- a/CataReforgeDetection.lua
+++ b/CataReforgeDetection.lua
@@ -186,7 +186,7 @@ local function GetItemCurrentStats(unit, itemSlot, enchantText)
         local region = regions[i]
         if region and region:GetObjectType() == "FontString" then
             local text = region:GetText()
-            if text and text ~= enchantText and not text:find(socketBonus) then
+            if text and text ~= enchantText and not text:find(socketBonus) and not text:find("^|") then
                 for statId, v in pairs(statIdToStrings) do
                     local pos = text:find(v.statStringNoVar)
                     if pos then


### PR DESCRIPTION
Fixes two separate issues with Reforge detection.

The fix for preventing detecting stats in enchants as reforge destStats should in theory use [`ItemMixin:ContinueOnItemLoad`](https://warcraft.wiki.gg/wiki/ItemMixin) to load the dummy item, but this would involve converting the entire export generation to use async callbacks, so instead it's a bit of a hackfix using `C_Item.RequestLoadItemDataByID` on initial load. This should work the vast majority of the time.