### PR TITLE
Update CreateEquipmentSpec to exclude version

### DIFF
--- a/ExportStructures/EquipmentSpec.lua
+++ b/ExportStructures/EquipmentSpec.lua
@@ -164,7 +164,7 @@ end
 -- Create a new EquipmentSpec table.
 local function CreateEquipmentSpec()
     local items = setmetatable({}, EquipmentSpecItemsMeta)
-    local equipment = setmetatable({ items = items, version = Env.VERSION }, EquipmentSpecMeta)
+    local equipment = setmetatable({ items = items }, EquipmentSpecMeta)
     return equipment
 end
 


### PR DESCRIPTION
Remove version from EquipmentSpec initialization.
It is included in the player details section