### PR TITLE
TBC: Fix: include class name in  wowsims.com links

### DIFF
--- a/Conditional_TBC.lua
+++ b/Conditional_TBC.lua
@@ -17,33 +17,33 @@ Env.supportedClasses = {
 
 local TblMaxValIdx = Env.TableMaxValIndex
 
-Env.AddSpec("shaman", "elemental", "elemental", function(t) return TblMaxValIdx(t) == 1 end)
-Env.AddSpec("shaman", "enhancement", "enhancement", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("shaman", "elemental", "shaman/elemental", function(t) return TblMaxValIdx(t) == 1 end)
+Env.AddSpec("shaman", "enhancement", "shaman/enhancement", function(t) return TblMaxValIdx(t) == 2 end)
 
-Env.AddSpec("hunter", "beast_mastery", "dps", function(t) return TblMaxValIdx(t) == 1 end)
-Env.AddSpec("hunter", "marksman", "dps", function(t) return TblMaxValIdx(t) == 2 end)
-Env.AddSpec("hunter", "survival", "dps", function(t) return TblMaxValIdx(t) == 3 end)
+Env.AddSpec("hunter", "beast_mastery", "hunter/dps", function(t) return TblMaxValIdx(t) == 1 end)
+Env.AddSpec("hunter", "marksman", "hunter/dps", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("hunter", "survival", "hunter/dps", function(t) return TblMaxValIdx(t) == 3 end)
 
-Env.AddSpec("druid", "balance", "balance", function(t) return TblMaxValIdx(t) == 1 end)
-Env.AddSpec("druid", "feral", "feralcat", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("druid", "balance", "druid/balance", function(t) return TblMaxValIdx(t) == 1 end)
+Env.AddSpec("druid", "feral", "druid/feralcat", function(t) return TblMaxValIdx(t) == 2 end)
 
-Env.AddSpec("warlock", "affliction", "dps", function(t) return TblMaxValIdx(t) == 1 end)
-Env.AddSpec("warlock", "demonology", "dps", function(t) return TblMaxValIdx(t) == 2 end)
-Env.AddSpec("warlock", "destruction", "dps", function(t) return TblMaxValIdx(t) == 3 end)
+Env.AddSpec("warlock", "affliction", "warlock/dps", function(t) return TblMaxValIdx(t) == 1 end)
+Env.AddSpec("warlock", "demonology", "warlock/dps", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("warlock", "destruction", "warlock/dps", function(t) return TblMaxValIdx(t) == 3 end)
 
-Env.AddSpec("rogue", "assassination", "dps", function(t) return TblMaxValIdx(t) == 1 end)
-Env.AddSpec("rogue", "combat", "dps", function(t) return TblMaxValIdx(t) == 2 end)
-Env.AddSpec("rogue", "subtlety", "dps", function(t) return TblMaxValIdx(t) == 3 end)
+Env.AddSpec("rogue", "assassination", "rogue/dps", function(t) return TblMaxValIdx(t) == 1 end)
+Env.AddSpec("rogue", "combat", "rogue/dps", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("rogue", "subtlety", "rogue/dps", function(t) return TblMaxValIdx(t) == 3 end)
 
-Env.AddSpec("mage", "arcane", "dps", function(t) return TblMaxValIdx(t) == 1 end)
-Env.AddSpec("mage", "fire", "dps", function(t) return TblMaxValIdx(t) == 2 end)
-Env.AddSpec("mage", "frost", "dps", function(t) return TblMaxValIdx(t) == 3 end)
+Env.AddSpec("mage", "arcane", "mage/dps", function(t) return TblMaxValIdx(t) == 1 end)
+Env.AddSpec("mage", "fire", "mage/dps", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("mage", "frost", "mage/dps", function(t) return TblMaxValIdx(t) == 3 end)
 
-Env.AddSpec("warrior", "arms", "dps", function(t) return TblMaxValIdx(t) == 1 end)
-Env.AddSpec("warrior", "fury", "dps", function(t) return TblMaxValIdx(t) == 2 end)
-Env.AddSpec("warrior", "protection", "protection", function(t) return TblMaxValIdx(t) == 3 end)
+Env.AddSpec("warrior", "arms", "warrior/dps", function(t) return TblMaxValIdx(t) == 1 end)
+Env.AddSpec("warrior", "fury", "warrior/dps", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("warrior", "protection", "warrior/protection", function(t) return TblMaxValIdx(t) == 3 end)
 
-Env.AddSpec("paladin", "protection", "protection", function(t) return TblMaxValIdx(t) == 2 end)
-Env.AddSpec("paladin", "retribution", "retribution", function(t) return TblMaxValIdx(t) == 3 end)
+Env.AddSpec("paladin", "protection", "paladin/protection", function(t) return TblMaxValIdx(t) == 2 end)
+Env.AddSpec("paladin", "retribution", "paladin/retribution", function(t) return TblMaxValIdx(t) == 3 end)
 
-Env.AddSpec("priest", "shadow", "shadow", function(t) return TblMaxValIdx(t) == 3 end)
+Env.AddSpec("priest", "shadow", "priest/shadow", function(t) return TblMaxValIdx(t) == 3 end)


### PR DESCRIPTION
Env.AddSpec URL suffixes for TBC were missing the class segment, so generated links (e.g. shaman elemental) pointed to wowsims.com/tbc/elemental instead of wowsims.com/tbc/shaman/elemental. Prepend the class to every spec's URL suffix.